### PR TITLE
Engine configuration@include model versioning engine configuration

### DIFF
--- a/lib/gemaker/cmds/create_engine.rb
+++ b/lib/gemaker/cmds/create_engine.rb
@@ -32,6 +32,8 @@ module Gemaker
 
       def add_lib_related
         extend_active_admin_config
+        extend_papertrail_engine_config
+        extend_paper_trail_gem_config
         add_engine_file
         add_errors_file
         add_main_file
@@ -71,6 +73,14 @@ module Gemaker
 
       def add_errors_file
         copy_template("engine/lib/errors.rb", "lib/#{gem_name}/errors.rb")
+      end
+
+      def extend_paper_trail_gem_config
+        copy_template("engine/lib/paper_trail_configuration.rb", "lib/#{gem_name}/paper_trail_configuration.rb")
+      end
+
+      def extend_papertrail_engine_config
+        copy_template("engine/lib/papertrail_config.rb", "lib/#{gem_name}/papertrail_config.rb")
       end
 
       def add_main_file

--- a/lib/gemaker/templates/engine/Gemfile
+++ b/lib/gemaker/templates/engine/Gemfile
@@ -5,4 +5,5 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
-gem "papertrail_config", path: "../papertrail_config"
+papertrail_config_path = Dir.glob(File.join(__FILE__[/^.*engines/], "**", "papertrail_config"))[0]
+gem "papertrail_config", path: papertrail_config_path

--- a/lib/gemaker/templates/engine/Gemfile
+++ b/lib/gemaker/templates/engine/Gemfile
@@ -4,3 +4,5 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
+
+gem "papertrail_config", path: "../papertrail_config"

--- a/lib/gemaker/templates/engine/lib/engine.rb.erb
+++ b/lib/gemaker/templates/engine/lib/engine.rb.erb
@@ -24,6 +24,7 @@ module <%= config.gem_class %>
     initializer "initialize" do
       require_relative "./errors"
       require_relative "./activeadmin_config"
+      require_relative "./papertrail_config"
     end
   end
 end

--- a/lib/gemaker/templates/engine/lib/main.rb.erb
+++ b/lib/gemaker/templates/engine/lib/main.rb.erb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
+require "papertrail_config"
 require "<%= config.gem_name %>/engine"
+require "<%= config.gem_name %>/paper_trail_configuration"
 
 module <%= config.gem_class %>
   extend self

--- a/lib/gemaker/templates/engine/lib/paper_trail_configuration.rb.erb
+++ b/lib/gemaker/templates/engine/lib/paper_trail_configuration.rb.erb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module <%= config.gem_class %>
+  class PaperTrailConfiguration
+    include PapertrailConfig::ConfigurationConcern
+
+    NON_VERSIONED_MODELS = %w()
+  end
+end

--- a/lib/gemaker/templates/engine/lib/papertrail_config.rb.erb
+++ b/lib/gemaker/templates/engine/lib/papertrail_config.rb.erb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+PapertrailConfig.configure do |config|
+  config.non_versioned_models.push(*<%= config.gem_class %>::PaperTrailConfiguration::NON_VERSIONED_MODELS)
+end

--- a/lib/gemaker/templates/engine/models/application_record.rb.erb
+++ b/lib/gemaker/templates/engine/models/application_record.rb.erb
@@ -2,6 +2,8 @@
 
 module <%= config.gem_class %>
   class ApplicationRecord < ActiveRecord::Base
+    include PapertrailConfig::ApplicationRecordConcern
+
     self.abstract_class = true
     self.table_name_prefix = '<%= config.gem_name %>_'
   end


### PR DESCRIPTION
**Contexto**

Para evitar que tengamos que configurar a mano el engine `PapertrailConfig` en los nuevos engines que construyamos usando `gemaker`, extendí esté último. Se agregan los archivos adicionales necesarios, y se hace `require` de estos donde corresponda.

**QA**

Correr el comando `bundle exec gemaker new my_engine` y revisar lo siguiente:
- Se crea el archivo `engines/my_engine/lib/my_engine/papertrail_config.rb` y se hace require de este en el archivo `engines/my_engine/lib/my_engine/engine.rb`
- Se crea el archivo `engines/my_engine/lib/my_engine/paper_trail_configuration.rb` y se hace require de este en el archivo `engines/my_engine/lib/my_engine.rb`
- Se hace require del nuevo engine `PapertrailConfig` en el archivo `engines/my_engine/lib/my_engine.rb`
- Se incluye `PapertrailConfig::ApplicationRecordConcern` en el `ApplicationRecord` del engine
- Se incluye engine `PapertrailConfig` en el `Gemfile`

Revisar que los archivos se crean con los nombres correctos, y con el nombre del módulo correcto (i.e. que correspondan con el nombre del engine)

Lo puedo hacer yo si les parece bien.