### PR TITLE
Support engine categories

### DIFF
--- a/lib/gemaker/cli.rb
+++ b/lib/gemaker/cli.rb
@@ -46,7 +46,11 @@ module Gemaker
       config.engine = agree("La gema es es un engine? Contesta 'yes' si tu gema funcionará como una extensión de Rails. Es decir, si agregará o extenderá models, controllers, etc.")
 
       if config.engine
-        config.gem_category = ask("Ingresa la categoría de este engine:")
+        while gem_category = ask("Ingresa la categoría de este engine:")
+          break if gem_category.present?
+        end
+
+        config.gem_category = gem_category
       end
     end
     # rubocop:enable Metrics/LineLength

--- a/lib/gemaker/cli.rb
+++ b/lib/gemaker/cli.rb
@@ -44,6 +44,10 @@ module Gemaker
       config.summary = ask("Ingresa un resumen de la gema (una oración):")
       config.description = ask("Ingresa la descripción de la gema (aquí esfuérzate un poco más):")
       config.engine = agree("La gema es es un engine? Contesta 'yes' si tu gema funcionará como una extensión de Rails. Es decir, si agregará o extenderá models, controllers, etc.")
+
+      if config.engine
+        config.gem_category = ask("Ingresa la categoría de este engine:")
+      end
     end
     # rubocop:enable Metrics/LineLength
 

--- a/lib/gemaker/cmds/base.rb
+++ b/lib/gemaker/cmds/base.rb
@@ -3,7 +3,7 @@
 module Gemaker
   module Cmds
     class Base < PowerTypes::Command.new(:config)
-      delegate :human_gem_name, :gem_name, :gem_directory, :gem_type,
+      delegate :human_gem_name, :gem_name, :gem_directory, :gem_type, :gem_category,
                to: :config, prefix: false, allow_nil: false
 
       def perform

--- a/lib/gemaker/cmds/create_engine.rb
+++ b/lib/gemaker/cmds/create_engine.rb
@@ -12,6 +12,8 @@ module Gemaker
         add_config_related
         add_lib_related
         add_root_related
+
+        move_to_category
       end
 
       def add_app_related
@@ -127,6 +129,11 @@ module Gemaker
         add_empty_directory("app/services/#{gem_name}")
         add_empty_directory("app/commands/#{gem_name}")
         add_empty_directory("app/values/#{gem_name}")
+      end
+
+      def move_to_category
+        execute("mkdir -p engines/#{gem_category}", "error creating category")
+        execute("mv engines/#{gem_name} engines/#{gem_category}/#{gem_name}", "error moving to category")
       end
     end
   end

--- a/lib/gemaker/config.rb
+++ b/lib/gemaker/config.rb
@@ -2,7 +2,7 @@
 
 module Gemaker
   class Config
-    attr_accessor :gem_name, :summary, :engine
+    attr_accessor :gem_name, :gem_category, :summary, :engine
     attr_writer :human_gem_name, :description
 
     def initialize

--- a/lib/gemaker/version.rb
+++ b/lib/gemaker/version.rb
@@ -1,3 +1,3 @@
 module Gemaker
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
### Contexto

- Se agrega `category` a la creación de engines

### QA

- Crear un `engine` con un `category` que ya exista
- Crear un engine con un category que no exista
- Crear una gema y verificar que no pregunte por la categoría