### PR TITLE
Use categories for gems as well

### DIFF
--- a/lib/gemaker/cli.rb
+++ b/lib/gemaker/cli.rb
@@ -36,22 +36,17 @@ module Gemaker
     def fill_config(gem_name, config)
       config.gem_name = gem_name
 
-      if config.gem_name.blank?
-        config.gem_name = ask("En nombre de la gema es obligatorio... Por favor, ingrésalo:")
+      while config.gem_name.blank?
+        config.gem_name = ask("El nombre de la gema es obligatorio... Por favor, ingrésalo:")
       end
-
+      while config.gem_category.blank?
+        config.gem_category = ask("Ingresa la categoría (stakeholders) de la gema:")
+      end
       config.human_gem_name = ask("Ingresa el nombre 'humano' de la gema. Por ejemplo: \"#{config.human_gem_name}\":")
       config.summary = ask("Ingresa un resumen de la gema (una oración):")
       config.description = ask("Ingresa la descripción de la gema (aquí esfuérzate un poco más):")
       config.engine = agree("La gema es es un engine? Contesta 'yes' si tu gema funcionará como una extensión de Rails. Es decir, si agregará o extenderá models, controllers, etc.")
 
-      if config.engine
-        while gem_category = ask("Ingresa la categoría de este engine:")
-          break if gem_category.present?
-        end
-
-        config.gem_category = gem_category
-      end
     end
     # rubocop:enable Metrics/LineLength
 

--- a/lib/gemaker/config.rb
+++ b/lib/gemaker/config.rb
@@ -38,8 +38,6 @@ module Gemaker
     end
 
     def gem_path
-      return File.join(gem_directory, gem_name) unless gem_category
-
       File.join(gem_directory, gem_category, gem_name)
     end
 


### PR DESCRIPTION
Teníamos distinto orden para gemas vs engines (no usábamos categorías con las gemas).

Este PR simplemente homologa eso.

### QA
Probar que se genere una gema dentro de su categoría correspondiente
Se puede probar en el monolito usando una copia de esta gema en local:
![image](https://user-images.githubusercontent.com/4401263/129617258-25ec9735-cd45-4ab3-bb15-2a28aa7190f3.png)