### PR TITLE
feat(specs): add to circleci config

### DIFF
--- a/lib/gemaker/cmds/base.rb
+++ b/lib/gemaker/cmds/base.rb
@@ -130,34 +130,9 @@ module Gemaker
       end
 
       def find_new_circleci_entry_index(config_yaml)
-        specs_for_gem_type_job_index = find_specs_for_gem_type_job_index(config_yaml)
-        steps_index = find_steps_index(config_yaml, specs_for_gem_type_job_index)
-        find_end_of_steps_index(config_yaml, steps_index)
-      end
-
-      def find_specs_for_gem_type_job_index(config_yaml)
-        index = config_yaml.index("  #{gem_type}s_specs:\n")
-        raise "#{gem_type}s_specs not configured in CircleCI" if index.nil?
+        index = 1 + config_yaml.index("      # #{gem_type}s_specs_list_reference_for_gemaker\n")
+        raise "Magic comment for #{gem_type}s specs not found in CircleCI's config" if index.nil?
         index
-      end
-
-      def find_steps_index(config_yaml, specs_for_gem_type_job_index)
-        config_yaml[specs_for_gem_type_job_index..].each_with_index do |line, index|
-          if line == "    steps:\n"
-            return index + specs_for_gem_type_job_index
-          end
-          raise "missing :steps entry in #{gem_type}s_specs, empty line found" if line == "\n"
-        end
-        raise "missing :steps entry in #{gem_type}s_specs, end of file reached"
-      end
-
-      def find_end_of_steps_index(config_yaml, steps_index)
-        config_yaml[steps_index..].each_with_index do |line, index|
-          if line == "\n"
-            return index + steps_index
-          end
-        end
-        raise "missing empty newline after #{gem_type}s_specs, end of file reached"
       end
 
       def new_circleci_entry


### PR DESCRIPTION
Para modificar el archivo de circleci automáticamente y todas las gemas y engines nuevos se consideren por defecto.

Probé esta otra forma, mucho más elegante:
```ruby
yaml = YAML.load_file CIRCLECI_CONFIG_YAML_PATH

yaml["jobs"]["#{gem_type}s_specs"]["steps"].append(
  {"run_#{gem_type}_specs"=>{"path"=>"#{gem_type}s/#{gem_category}/#{gem_name}"}}
)

File.write(CIRCLECI_CONFIG_YAML_PATH, YAML.dump yaml)
```

Pero lamentablemente al parsear un YAML se pierden los anchors y demases, por lo que me vi obligado a apllicar una estrategia más bruta para modificar el archivo. No me gusta mucho como quedó eso sí, se reciben sugerencias!

### QA
Generar una nueva gema y/o engine y verificar que se modifica como se espera