### PR TITLE
updated parent class for application record

### DIFF
--- a/lib/gemaker/templates/engine/Gemfile.erb
+++ b/lib/gemaker/templates/engine/Gemfile.erb
@@ -5,4 +5,5 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
+gem "fintual_active_record", path: "../../../gems/architecture/fintual_active_record"
 gem "papertrail_config", path: "<%= config.relative_path_to("architecture/papertrail_config") %>"

--- a/lib/gemaker/templates/engine/app/models/application_record.rb.erb
+++ b/lib/gemaker/templates/engine/app/models/application_record.rb.erb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module <%= config.gem_class %>
-  class ApplicationRecord < ActiveRecord::Base
+  class ApplicationRecord < FintualActiveRecord::Base
     include PapertrailConfig::ApplicationRecordConcern
 
     self.abstract_class = true


### PR DESCRIPTION
Since we're now using `FintualActiveRecord` as base for `ApplicationRecord` we've updated gemaker to reflect this change.

QA:
en el monolito:
```sh
git checkout gemaker-application-record-qa
bundle exec gemaker new
# Aquí hay que ingresar una serie de cosas y crear un engine
# Irse a la carpeta del engine (cd engines/mi/engine)

bin/rails g model test_model
bin/rails db:create RAILS_ENV=development 
bin/rails db:migrate RAILS_ENV=development
bin/rails c
```
Después se puede verificar con `MyEngine::TestModel.superclass.superclass`