### PR TITLE
Force ruby platform

### DIFF
--- a/lib/gemaker/cmds/base.rb
+++ b/lib/gemaker/cmds/base.rb
@@ -43,6 +43,7 @@ module Gemaker
       end
 
       def execute_bundle
+        execute("bundle config force_ruby_platform true --local", "error setting ruby platform")
         execute("bundle install", "error running bundle install")
       end
 

--- a/lib/gemaker/cmds/base.rb
+++ b/lib/gemaker/cmds/base.rb
@@ -64,10 +64,10 @@ module Gemaker
       end
 
       def execute_within_gem(cmd, error_message = nil)
-        cmd = "(cd #{gem_root_path} && #{cmd})"
         Bundler.with_unbundled_env do
-          system cmd
+          system "(cd #{gem_root_path} && #{cmd})"
         end
+
         error(error_message) if $?.exitstatus != 0
       end
 

--- a/lib/gemaker/cmds/base.rb
+++ b/lib/gemaker/cmds/base.rb
@@ -14,6 +14,7 @@ module Gemaker
         add_initializer
         add_to_circleci if circleci_integrated?
         execute_bundle
+        execute_gem_bundle
       end
 
       private
@@ -43,12 +44,30 @@ module Gemaker
       end
 
       def execute_bundle
-        execute("bundle config force_ruby_platform true --local", "error setting ruby platform")
         execute("bundle install", "error running bundle install")
       end
 
       def execute(cmd, error_message = nil)
         system cmd
+        error(error_message) if $?.exitstatus != 0
+      end
+
+      def execute_gem_bundle
+        execute_within_gem(
+          "bundle config force_ruby_platform true --local",
+          "error setting ruby platform"
+        )
+        execute_within_gem(
+          "bundle install",
+          "error running bundle install"
+        )
+      end
+
+      def execute_within_gem(cmd, error_message = nil)
+        cmd = "(cd #{gem_root_path} && #{cmd})"
+        Bundler.with_unbundled_env do
+          system cmd
+        end
         error(error_message) if $?.exitstatus != 0
       end
 


### PR DESCRIPTION
Cuando se crea una gema o engine nuevo, no se corría bundle install dentro de la gema.
Al correrlo en local con `bundle install` se crea el lock file con la plataforma específica del computador donde se corra.

Para evitar eso agrego el paso de bundle install dentro del engine, fijando la plataforma a "ruby".